### PR TITLE
Use alpine:latest. Fix #22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:latest
 
 
 RUN apk --update add --no-cache python2 py2-requests py2-pip py2-lxml py2-requests openssl ca-certificates


### PR DESCRIPTION
py2-lxml package is not available in alpine:edge, which breaks building the docker image
Use alpine:latest instead (currently 3.10.3) to fix...