### PR TITLE
Use fixed version alpine:3.10. Fix issue #22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.10
 
 
 RUN apk --update add --no-cache python2 py2-requests py2-pip py2-lxml py2-requests openssl ca-certificates


### PR DESCRIPTION
alpine:latest is now pointing to 3.11, which does not contain required dependencies py2-lxml and py2-requests